### PR TITLE
Updates node-pre-gyp

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
   "main": "./canvas/lib/canvas.js",
   "license": "MIT",
   "dependencies": {
-    "node-pre-gyp": "^0.6.29"
+    "node-pre-gyp": "^0.10.0"
   }
 }


### PR DESCRIPTION
Could use a release with this upgrade for 1.x.x

Accidentally did this change against master, which fixes 2.0.0, but I need this resolved in 1.x.x.

Can you merge this, and tag a new 1.x.x release and publish to NPM?