### PR TITLE
Use --target instead of building with each node version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,6 @@ install:
 
     export PREBUILD_SLUG="$TRAVIS_REPO_SLUG";
 
-    bash ci/install.sh osx "$PREBUILD_VERSION" "$PREBUILD_CANVAS_VERSION" "$PREBUILD_NODE_VERSIONS";
+    bash -c 'export NVM_DIR=$HOME/.nvm; . $HOME/.nvm/nvm.sh; . ci/install.sh osx "$PREBUILD_VERSION" "$PREBUILD_CANVAS_VERSION" "$PREBUILD_NODE_VERSIONS"';
 
     fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 version: 0.0.{build}
 image: Visual Studio 2017
 install:
-  - ps: Install-Product node 8 x64
+  - ps: Install-Product node 10 x64
   - set PREBUILD_SLUG=%APPVEYOR_REPO_NAME%
   - npm install -g npm node-gyp
   - set "PATH=%APPDATA%\npm;%PATH%"

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -32,13 +32,11 @@ source ci/$OS/preinstall.sh
 cp ci/$OS/binding.gyp node-canvas/binding.gyp
 
 for ver in $NODEJS_VERSIONS; do 
-  echo "------------ Building with node $ver ------------"
-
-  source ci/$OS/node_version.sh $ver;
+  echo "------------ Building for node $ver ------------"
 
   cd node-canvas
 
-  node-gyp rebuild || {
+  node-gyp rebuild --target=$ver || {
     echo "error building in nodejs version $ver"
     exit 1;
   }
@@ -56,7 +54,6 @@ for ver in $NODEJS_VERSIONS; do
 done;
 
 echo "------------ Releasing with release.js ------------"
-source ci/$OS/node_version.sh 11
 node ci/release.js $PREBUILD_VERSION || exit 1;
 
 cd ..

--- a/ci/linux/node_version.sh
+++ b/ci/linux/node_version.sh
@@ -1,5 +1,0 @@
-VER=$1
-source ~/.nvm/nvm.sh
-nvm use $VER || { nvm install $VER; nvm use $VER; }
-npm install -g node-gyp
-

--- a/ci/linux/preinstall.sh
+++ b/ci/linux/preinstall.sh
@@ -1,6 +1,10 @@
 # apt-get-style dependencies aren't done here since the
 # linux build is done on a docker image that has them
 
+nvm install node # latest
+nvm use node # latest
+npm install -g node-gyp
+
 git clone git://anongit.gentoo.org/proj/pax-utils.git
 cd pax-utils
 PATH=$PATH:$PWD

--- a/ci/osx/node_version.sh
+++ b/ci/osx/node_version.sh
@@ -1,5 +1,0 @@
-VER=$1
-source ~/.nvm/nvm.sh
-nvm use $VER || { nvm install $VER; nvm use $VER; }
-npm install -g node-gyp
-

--- a/ci/osx/preinstall.sh
+++ b/ci/osx/preinstall.sh
@@ -1,3 +1,7 @@
+nvm install node # latest
+nvm use node # latest
+npm install -g node-gyp
+
 brew update
 brew install cairo pango librsvg python3 # python3 is for macpack
 brew upgrade python # activates python 3

--- a/ci/win/node_version.sh
+++ b/ci/win/node_version.sh
@@ -1,2 +1,0 @@
-VER=$1
-powershell -Command "Install-Product node $VER x64"


### PR DESCRIPTION
I have not tested this, but this should avoid the issue with Appveyor being slow to update their images and speed up the builds.

I don't know what $NODEJS_VERSIONS looks like; the `--target` option takes a full `vX.Y.Z` string, not just `X`. If you're only using `X` you could change it to `--target=v$ver.0.0`.