### PR TITLE
Add musl build based on alpine linux image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,15 @@ install:
   - >- # this should only run on linux
     if [ $TRAVIS_OS_NAME = "linux" ]; then
 
+    docker build -t canvas-musl-prebuilt:latest -f docker/Dockerfile.musl .;
+    docker run
+    -e PREBUILD_VERSION="$PREBUILD_VERSION"
+    -e PREBUILD_AUTH="$PREBUILD_AUTH"
+    -e PREBUILD_SLUG="$TRAVIS_REPO_SLUG"
+    -e PREBUILD_NODE_VERSIONS="$PREBUILD_NODE_VERSIONS"
+    -v $(pwd):/build canvas-musl-prebuilt:latest
+    bash -c 'cd /build; export NVM_DIR=$HOME/.nvm; . $HOME/.nvm/nvm.sh; . ci/install.sh linux '"\"$PREBUILD_VERSION\" \"$PREBUILD_CANVAS_VERSION\" \"$PREBUILD_NODE_VERSIONS\"";
+
     docker run
     -e PREBUILD_VERSION="$PREBUILD_VERSION"
     -e PREBUILD_AUTH="$PREBUILD_AUTH"

--- a/ci/linux/bundle.sh
+++ b/ci/linux/bundle.sh
@@ -1,4 +1,4 @@
-copies=$(lddtree.sh -l node-canvas/build/Release/canvas.node | sed -r -e '/^\/lib/d' -e '/canvas.node$/d');
+copies=$(lddtree -l node-canvas/build/Release/canvas.node | sed -r -e '/^\/lib/d' -e '/canvas.node$/d');
 
 for so in $copies; do
   cp $so node-canvas/build/Release

--- a/ci/linux/node_version.sh
+++ b/ci/linux/node_version.sh
@@ -1,5 +1,5 @@
 VER=$1
 source ~/.nvm/nvm.sh
+source ~/.profile
 nvm use $VER || { nvm install $VER; nvm use $VER; }
 npm install -g node-gyp
-

--- a/docker/Dockerfile.musl
+++ b/docker/Dockerfile.musl
@@ -1,0 +1,46 @@
+FROM alpine:3.11
+RUN apk update && apk add --no-cache \
+build-base \
+g++ \
+cairo-dev \
+jpeg-dev \
+pango-dev \
+giflib-dev \
+curl \
+bash \
+coreutils \
+libstdc++ \
+git \
+librsvg-dev \
+lddtree \
+pax-utils \
+zlib-dev \
+libffi-dev \
+libpng-dev \
+libjpeg-turbo-dev \
+fribidi-dev \
+pcre-dev \
+glib-dev \
+freetype-dev \
+harfbuzz-dev \
+expat-dev \
+fontconfig-dev \
+pixman-dev \
+python2 \
+gdk-pixbuf-dev \
+libxml2-dev \
+libcroco-dev
+
+RUN bash -c 'touch ~/.profile'
+
+# https://stackoverflow.com/questions/52196518/could-not-get-uid-gid-when-building-node-docker
+ENV npm_config_unsafe_perm=true
+# Suppress g++ casting warnings that come from node, nan and v8 (https://github.com/nodejs/nan/issues/807)
+ENV CXXFLAGS="-Wno-cast-function-type"
+RUN curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.1/install.sh | bash
+
+# Get nvm to work with alpine https://github.com/nvm-sh/nvm/issues/1102#issuecomment-550572252
+RUN bash -c 'echo "NVM_NODEJS_ORG_MIRROR=https://unofficial-builds.nodejs.org/download/release" >> ~/.profile'
+RUN bash -c 'echo "nvm_get_arch() { nvm_echo \"x64-musl\"; }" >> ~/.profile'
+
+RUN bash -c 'source ~/.profile; cd; nvm install v12'


### PR DESCRIPTION
This is an attempt to add pre-built musl binaries, ref #77 

For some reason this only works for nodejs v12 and higher. The binary builds without errors on lower versions but the final `node -e "require('./node-canvas')"` test results in a Segmentation Fault.  I have tried trouble shooting it but can't seem to get anywhere. If you have any ideas why this would be I would appreciate a second set of 👀 .

In the meantime it seems adding node 12 and 13 musl binaries would still be of value so I'm opening this PR now for review, please let me know what you think.